### PR TITLE
fix an empty list issue in the `ros2cli` package

### DIFF
--- a/ros2cli/usr_src/0001-fix-ros2-run-command-on-VxWorks.patch
+++ b/ros2cli/usr_src/0001-fix-ros2-run-command-on-VxWorks.patch
@@ -1,0 +1,43 @@
+From 8bc8d7a840298c403bf17cc803711bc713c249e4 Mon Sep 17 00:00:00 2001
+From: Andrei Kholodnyi <andrei.kholodnyi@gmail.com>
+Date: Thu, 21 Jul 2022 00:29:40 +0200
+Subject: [PATCH] fix ros2 run command on VxWorks
+
+---
+ ros2run/ros2run/api/__init__.py | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/ros2run/ros2run/api/__init__.py b/ros2run/ros2run/api/__init__.py
+index f1f9ed4..e640b33 100644
+--- a/ros2run/ros2run/api/__init__.py
++++ b/ros2run/ros2run/api/__init__.py
+@@ -15,6 +15,7 @@
+ import os
+ import subprocess
+ import sys
++from elftools.elf.elffile import ELFFile
+ 
+ from ros2pkg.api import get_executable_paths
+ from ros2pkg.api import PackageNotFound
+@@ -55,6 +56,18 @@ def run_executable(*, path, argv, prefix=None):
+     if os.name == 'nt' and path.endswith('.py'):
+         cmd.insert(0, sys.executable)
+ 
++    # on VxWorks Python scripts are invokable through the interpreter
++    if sys.platform == 'vxworks':
++        pyfmt = False
++        f = open(path, 'rb')
++        try:
++            elf = ELFFile(f)
++        except Exception as e:
++            pyfmt = True
++
++        if pyfmt:
++            cmd.insert(0, sys.executable)
++
+     if prefix is not None:
+         cmd = prefix + cmd
+ 
+-- 
+2.34.1
+

--- a/ros2cli/usr_src/0001-use-stat-instead-of-access-to-find-executables.patch
+++ b/ros2cli/usr_src/0001-use-stat-instead-of-access-to-find-executables.patch
@@ -1,0 +1,34 @@
+From 9b5eb4403a5df6946613fff9ac5e814c34b4d788 Mon Sep 17 00:00:00 2001
+From: Andrei Kholodnyi <andrei.kholodnyi@gmail.com>
+Date: Tue, 19 Jul 2022 23:31:25 +0200
+Subject: [PATCH] use stat instead of access to find executables
+
+---
+ ros2pkg/ros2pkg/api/__init__.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/ros2pkg/ros2pkg/api/__init__.py b/ros2pkg/ros2pkg/api/__init__.py
+index dbc5bd4..405ca38 100644
+--- a/ros2pkg/ros2pkg/api/__init__.py
++++ b/ros2pkg/ros2pkg/api/__init__.py
+@@ -13,6 +13,7 @@
+ # limitations under the License.
+ 
+ import os
++import stat
+ 
+ from ament_index_python import get_package_prefix
+ from ament_index_python import get_packages_with_prefixes
+@@ -50,7 +51,8 @@ def get_executable_paths(*, package_name):
+         # select executable files
+         for filename in sorted(filenames):
+             path = os.path.join(dirpath, filename)
+-            if os.access(path, os.X_OK):
++            st = os.stat(path)
++            if (st[stat.ST_MODE]&stat.S_IXUSR) != 0:
+                 executable_paths.append(path)
+     return executable_paths
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
fix [#30](https://github.com/Wind-River/vxworks7-ros2-build/issues/30)
VxWorks does not support the `access` function properly, use `stat` to identify whether the file is executable.
VxWorks cannot run python script directly, use a python interpreter for it, similar to Windows, and check a binary file before running it.
